### PR TITLE
Fix KintoneColumnVisitor.setField

### DIFF
--- a/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
@@ -59,27 +59,25 @@ public class KintoneColumnVisitor
                 .setField(fieldCode)
                 .setValue(String.valueOf(value));
         }
-        else {
-            String stringValue = String.valueOf(value);
-            FieldValue fieldValue = null;
-            switch (type) {
-                case NUMBER:
-                    fieldValue = new NumberFieldValue(new BigDecimal(stringValue));
-                    break;
-                case MULTI_LINE_TEXT:
-                    fieldValue = new MultiLineTextFieldValue(stringValue);
-                    break;
-                case DROP_DOWN:
-                    fieldValue = new DropDownFieldValue(stringValue);
-                    break;
-                case LINK:
-                    fieldValue = new LinkFieldValue(stringValue);
-                    break;
-                default:
-                    fieldValue = new SingleLineTextFieldValue(stringValue);
-            }
-            record.putField(fieldCode, fieldValue);
+        String stringValue = String.valueOf(value);
+        FieldValue fieldValue = null;
+        switch (type) {
+            case NUMBER:
+                fieldValue = new NumberFieldValue(new BigDecimal(stringValue));
+                break;
+            case MULTI_LINE_TEXT:
+                fieldValue = new MultiLineTextFieldValue(stringValue);
+                break;
+            case DROP_DOWN:
+                fieldValue = new DropDownFieldValue(stringValue);
+                break;
+            case LINK:
+                fieldValue = new LinkFieldValue(stringValue);
+                break;
+            default:
+                fieldValue = new SingleLineTextFieldValue(stringValue);
         }
+        record.putField(fieldCode, fieldValue);
     }
 
     private void setTimestampValue(String fieldCode, Instant instant, ZoneId zoneId, FieldType type)


### PR DESCRIPTION
Put all data into `record`.
Put all the data in case inserts are performed on the `upsertPage`.
In the case of update, we are deleting updatekey data.

I wanted to prioritize #11 in the merge, but #14 seems to have taken precedence.