### PR TITLE
Move update_key config from column_options to upper layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ kintone output plugin for Embulk stores app records from kintone.
 - **basic_auth_password**:  kintone basic auth password (string, optional)
 - **guest_space_id**: kintone app belongs to guest space, guest space id is required. (integer, optional)
 - **mode**: kintone mode (string, required)
+- **update_key**: column name to set update key (string, required if mode is update or upsert)
 - **column_options** advanced: a key-value pairs where key is a column name and value is options for the column.
     - **field_code**: field code (string, required)
     - **type**: field type (string, required)
     - **timezone**: timezone to convert into `date` (string, default is `UTC`)
-    - **update_key**: update key (boolean, default is `false`)
     - **val_sep**: Used to specify multiple checkbox values (string, default is `,`)
 
 ## Example
@@ -33,7 +33,8 @@ out:
   username: username
   password: password
   app_id: 1
-  mode: insert
+  mode: upsert
+  update_key: id
   column_options:
     id: {field_code: "id", type: "NUMBER"}
     name: {field_code: "name", type: "SINGLE_LINE_TEXT"}

--- a/src/main/java/org/embulk/output/kintone/KintoneColumnOption.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneColumnOption.java
@@ -19,10 +19,6 @@ public interface KintoneColumnOption
     @ConfigDefault("\"UTC\"")
     public Optional<String> getTimezone();
 
-    @Config("update_key")
-    @ConfigDefault("false")
-    public boolean getUpdateKey();
-
     @Config("val_sep")
     @ConfigDefault("\",\"")
     public String getValueSeparator();

--- a/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
@@ -70,7 +70,8 @@ public class KintoneColumnVisitor
         FieldValue fieldValue;
         switch (type) {
             case NUMBER:
-                fieldValue = new NumberFieldValue(new BigDecimal(stringValue));
+                BigDecimal setValue = stringValue.equals("") ? null : new BigDecimal(stringValue);
+                fieldValue = new NumberFieldValue(setValue);
                 break;
             case MULTI_LINE_TEXT:
                 fieldValue = new MultiLineTextFieldValue(stringValue);
@@ -169,7 +170,11 @@ public class KintoneColumnVisitor
     {
         String fieldCode = getFieldCode(column);
         FieldType type = getType(column, FieldType.NUMBER);
-        setValue(fieldCode, pageReader.getLong(column), type, isUpdateKey(column));
+        if (pageReader.isNull(column)) {
+            setValue(fieldCode, null, type, isUpdateKey(column));
+        } else {
+            setValue(fieldCode, pageReader.getLong(column), type, isUpdateKey(column));
+        }
     }
 
     @Override

--- a/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Objects;
 
 public class KintoneColumnVisitor
         implements ColumnVisitor
@@ -60,17 +61,13 @@ public class KintoneColumnVisitor
 
     private void setValue(String fieldCode, Object value, FieldType type, boolean isUpdateKey)
     {
-        if (value == null) {
-            return;
-        }
-
         if (isUpdateKey && updateKey != null) {
             updateKey
                 .setField(fieldCode)
-                .setValue(String.valueOf(value));
+                .setValue(Objects.toString(value, ""));
         }
-        String stringValue = String.valueOf(value);
-        FieldValue fieldValue = null;
+        String stringValue = Objects.toString(value, "");
+        FieldValue fieldValue;
         switch (type) {
             case NUMBER:
                 fieldValue = new NumberFieldValue(new BigDecimal(stringValue));

--- a/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneColumnVisitor.java
@@ -30,12 +30,22 @@ public class KintoneColumnVisitor
     private Record record;
     private UpdateKey updateKey;
     private Map<String, KintoneColumnOption> columnOptions;
+    private String updateKeyName;
 
     public KintoneColumnVisitor(PageReader pageReader,
                                 Map<String, KintoneColumnOption> columnOptions)
     {
         this.pageReader = pageReader;
         this.columnOptions = columnOptions;
+    }
+
+    public KintoneColumnVisitor(PageReader pageReader,
+                                Map<String, KintoneColumnOption> columnOptions,
+                                String updateKeyName)
+    {
+        this.pageReader = pageReader;
+        this.columnOptions = columnOptions;
+        this.updateKeyName = updateKeyName;
     }
 
     public void setRecord(Record record)
@@ -133,11 +143,11 @@ public class KintoneColumnVisitor
 
     private boolean isUpdateKey(Column column)
     {
-        KintoneColumnOption option = columnOptions.get(column.getName());
-        if (option == null) {
+        if (this.updateKeyName == null) {
             return false;
         }
-        return option.getUpdateKey();
+
+        return this.updateKeyName.equals(column.getName());
     }
 
     private String getValueSeparator(Column column)

--- a/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
@@ -50,28 +50,14 @@ public class KintoneOutputPlugin
         KintoneMode mode = KintoneMode.getKintoneModeByValue(task.getMode());
         switch (mode) {
             case INSERT:
-                for (KintoneColumnOption option : options) {
-                    if (option.getUpdateKey()) {
-                        throw new IllegalArgumentException(
-                                "when mode is insert, require no update_key.");
-                    }
+                if (task.getUpdateKeyName() != null) {
+                    throw new IllegalArgumentException("when mode is insert, require no update_key.");
                 }
                 break;
             case UPDATE:
             case UPSERT:
-                boolean hasUpdateKey = false;
-                for (KintoneColumnOption option : options) {
-                    if (option.getUpdateKey()) {
-                        if (hasUpdateKey) {
-                            throw new IllegalArgumentException(
-                                    "when mode is update and upsert, only one column can have an update_key.");
-                        }
-                        hasUpdateKey = true;
-                    }
-                }
-                if (!hasUpdateKey) {
-                    throw new IllegalArgumentException(
-                            "when mode is update and upsert, require update_key.");
+                if (task.getUpdateKeyName() == null) {
+                    throw new IllegalArgumentException("when mode is update and upsert, require update_key.");
                 }
                 break;
             default:

--- a/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
@@ -50,13 +50,13 @@ public class KintoneOutputPlugin
         KintoneMode mode = KintoneMode.getKintoneModeByValue(task.getMode());
         switch (mode) {
             case INSERT:
-                if (task.getUpdateKeyName() != null) {
+                if (task.getUpdateKeyName().isPresent()) {
                     throw new IllegalArgumentException("when mode is insert, require no update_key.");
                 }
                 break;
             case UPDATE:
             case UPSERT:
-                if (task.getUpdateKeyName() == null) {
+                if (!task.getUpdateKeyName().isPresent()) {
                     throw new IllegalArgumentException("when mode is update and upsert, require update_key.");
                 }
                 break;

--- a/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
@@ -57,7 +57,7 @@ public class KintoneOutputPlugin
             case UPDATE:
             case UPSERT:
                 if (!task.getUpdateKeyName().isPresent()) {
-                    throw new IllegalArgumentException("when mode is update and upsert, require update_key.");
+                    throw new IllegalArgumentException("when mode is update or upsert, require update_key.");
                 }
                 break;
             default:

--- a/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
@@ -1,6 +1,7 @@
 package org.embulk.output.kintone;
 
 import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
@@ -51,17 +52,17 @@ public class KintoneOutputPlugin
         switch (mode) {
             case INSERT:
                 if (task.getUpdateKeyName().isPresent()) {
-                    throw new IllegalArgumentException("when mode is insert, require no update_key.");
+                    throw new ConfigException("when mode is insert, require no update_key.");
                 }
                 break;
             case UPDATE:
             case UPSERT:
                 if (!task.getUpdateKeyName().isPresent()) {
-                    throw new IllegalArgumentException("when mode is update or upsert, require update_key.");
+                    throw new ConfigException("when mode is update or upsert, require update_key.");
                 }
                 break;
             default:
-                throw new IllegalArgumentException(String.format(
+                throw new ConfigException(String.format(
                         "Unknown mode '%s'",
                         task.getMode()));
         }

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -173,6 +173,10 @@ public class KintonePageOutput
                         column.visit(visitor);
                     }
 
+                    if (updateKey.getValue() == "") {
+                        continue;
+                    }
+
                     record.removeField(updateKey.getField());
                     updateRecords.add(new RecordForUpdate(updateKey, record));
                     if (updateRecords.size() == 100) {

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -154,7 +154,7 @@ public class KintonePageOutput
         execute(client -> {
             try {
                 if (!task.getUpdateKeyName().isPresent()) {
-                    // KintoneOutputPlugin.open() で validation 済み
+                    // already validated in KintoneOutputPlugin.open()
                     throw new RuntimeException("unreachable error");
                 }
                 ArrayList<RecordForUpdate> updateRecords = new ArrayList<RecordForUpdate>();
@@ -194,7 +194,7 @@ public class KintonePageOutput
         execute(client -> {
             try {
                 if (!task.getUpdateKeyName().isPresent()) {
-                    // KintoneOutputPlugin.open() で validation 済み
+                    // already validated in KintoneOutputPlugin.open()
                     throw new RuntimeException("unreachable error");
                 }
                 ArrayList<Record> records = new ArrayList<>();

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -158,7 +158,7 @@ public class KintonePageOutput
                 ArrayList<RecordForUpdate> updateRecords = new ArrayList<RecordForUpdate>();
                 pageReader.setPage(page);
                 KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,
-                        task.getColumnOptions());
+                        task.getColumnOptions(), task.getUpdateKeyName());
                 while (pageReader.nextRecord()) {
                     Record record = new Record();
                     UpdateKey updateKey = new UpdateKey();

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -153,11 +153,16 @@ public class KintonePageOutput
     {
         execute(client -> {
             try {
+                if (!task.getUpdateKeyName().isPresent()) {
+                    // KintoneOutputPlugin.open() で validation 済み
+                    throw new RuntimeException("unreachable error");
+                }
                 ArrayList<RecordForUpdate> updateRecords = new ArrayList<RecordForUpdate>();
                 pageReader.setPage(page);
+
                 KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,
                         task.getColumnOptions(),
-                        task.getUpdateKeyName());
+                        task.getUpdateKeyName().get());
                 while (pageReader.nextRecord()) {
                     Record record = new Record();
                     UpdateKey updateKey = new UpdateKey();
@@ -188,13 +193,17 @@ public class KintonePageOutput
     {
         execute(client -> {
             try {
+                if (!task.getUpdateKeyName().isPresent()) {
+                    // KintoneOutputPlugin.open() で validation 済み
+                    throw new RuntimeException("unreachable error");
+                }
                 ArrayList<Record> records = new ArrayList<>();
                 ArrayList<UpdateKey> updateKeys = new ArrayList<>();
-
                 pageReader.setPage(page);
+
                 KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,
                         task.getColumnOptions(),
-                        task.getUpdateKeyName());
+                        task.getUpdateKeyName().get());
                 while (pageReader.nextRecord()) {
                     Record record = new Record();
                     UpdateKey updateKey = new UpdateKey();

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -241,7 +241,7 @@ public class KintonePageOutput
             throw new RuntimeException("records.size() != updateKeys.size()");
         }
 
-        List<Record> existingRecords = getExiststingRecordsByUpdateKey(updateKeys);
+        List<Record> existingRecords = getExistingRecordsByUpdateKey(updateKeys);
 
         ArrayList<Record> insertRecords = new ArrayList<>();
         ArrayList<RecordForUpdate> updateRecords = new ArrayList<>();
@@ -249,7 +249,7 @@ public class KintonePageOutput
             Record record = records.get(i);
             UpdateKey updateKey = updateKeys.get(i);
 
-            if (existsRecord(distRecords, updateKey)) {
+            if (existsRecord(existingRecords, updateKey)) {
                 record.removeField(updateKey.getField());
                 updateRecords.add(new RecordForUpdate(updateKey, record));
             }
@@ -275,7 +275,7 @@ public class KintonePageOutput
     }
 
 
-    private List<Record> getRecordsByUpdateKey(ArrayList<UpdateKey> updateKeys)
+    private List<Record> getExistingRecordsByUpdateKey(ArrayList<UpdateKey> updateKeys)
     {
         String fieldCode = updateKeys.get(0).getField();
         List<String> queryValues = updateKeys

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -13,6 +13,7 @@ import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -245,13 +246,13 @@ public class KintonePageOutput
             Record record = records.get(i);
             UpdateKey updateKey = updateKeys.get(i);
 
-           if (existsRecord(distRecords, updateKey)) {
-               record.removeField(updateKey.getField());
-               updateRecords.add(new RecordForUpdate(updateKey, record));
-           }
-           else {
-               insertRecords.add(record);
-           }
+            if (existsRecord(distRecords, updateKey)) {
+                record.removeField(updateKey.getField());
+                updateRecords.add(new RecordForUpdate(updateKey, record));
+            }
+            else {
+                insertRecords.add(record);
+            }
 
             if (insertRecords.size() == 100) {
                 client.record().addRecords(task.getAppId(), insertRecords);
@@ -276,10 +277,14 @@ public class KintonePageOutput
         String fieldCode = updateKeys.get(0).getField();
         List<String> queryValues = updateKeys
                 .stream()
+                .filter(k -> k.getValue() != "")
                 .map(k -> "\"" + k.getValue().toString() + "\"")
                 .collect(Collectors.toList());
 
         List<Record> allRecords = new ArrayList<>();
+        if (queryValues.isEmpty()) {
+            return allRecords;
+        }
         String cursorId = client.record().createCursor(
             task.getAppId(),
             Arrays.asList(fieldCode),

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -3,7 +3,6 @@ package org.embulk.output.kintone;
 import com.kintone.client.KintoneClient;
 import com.kintone.client.KintoneClientBuilder;
 import com.kintone.client.api.record.GetRecordsByCursorResponseBody;
-import com.kintone.client.model.app.field.FieldProperty;
 import com.kintone.client.model.record.*;
 import com.kintone.client.model.record.Record;
 import org.embulk.config.TaskReport;
@@ -14,11 +13,9 @@ import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class KintonePageOutput

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -3,8 +3,10 @@ package org.embulk.output.kintone;
 import com.kintone.client.KintoneClient;
 import com.kintone.client.KintoneClientBuilder;
 import com.kintone.client.api.record.GetRecordsByCursorResponseBody;
-import com.kintone.client.model.record.*;
+import com.kintone.client.model.record.FieldType;
 import com.kintone.client.model.record.Record;
+import com.kintone.client.model.record.RecordForUpdate;
+import com.kintone.client.model.record.UpdateKey;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
@@ -157,7 +159,7 @@ public class KintonePageOutput
                     // already validated in KintoneOutputPlugin.open()
                     throw new RuntimeException("unreachable error");
                 }
-                ArrayList<RecordForUpdate> updateRecords = new ArrayList<RecordForUpdate>();
+                ArrayList<RecordForUpdate> updateRecords = new ArrayList<>();
                 pageReader.setPage(page);
 
                 KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -261,11 +261,11 @@ public class KintonePageOutput
                 insertRecords.add(record);
             }
 
-            if (insertRecords.size() == 100) {
+            if (insertRecords.size() == CHUNK_SIZE) {
                 client.record().addRecords(task.getAppId(), insertRecords);
                 insertRecords.clear();
             }
-            else if (updateRecords.size() == 100) {
+            else if (updateRecords.size() == CHUNK_SIZE) {
                 client.record().updateRecords(task.getAppId(), updateRecords);
                 updateRecords.clear();
             }

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -158,7 +158,8 @@ public class KintonePageOutput
                 ArrayList<RecordForUpdate> updateRecords = new ArrayList<RecordForUpdate>();
                 pageReader.setPage(page);
                 KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,
-                        task.getColumnOptions(), task.getUpdateKeyName());
+                        task.getColumnOptions(),
+                        task.getUpdateKeyName());
                 while (pageReader.nextRecord()) {
                     Record record = new Record();
                     UpdateKey updateKey = new UpdateKey();
@@ -263,7 +264,8 @@ public class KintonePageOutput
 
                     pageReader.setPage(page);
                     KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,
-                            task.getColumnOptions());
+                            task.getColumnOptions(),
+                            task.getUpdateKeyName());
                     while (pageReader.nextRecord()) {
                         Record record = new Record();
                         UpdateKey updateKey = new UpdateKey();

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -241,7 +241,7 @@ public class KintonePageOutput
             throw new RuntimeException("records.size() != updateKeys.size()");
         }
 
-        List<Record> distRecords = getRecordsByUpdateKey(updateKeys);
+        List<Record> existingRecords = getExiststingRecordsByUpdateKey(updateKeys);
 
         ArrayList<Record> insertRecords = new ArrayList<>();
         ArrayList<RecordForUpdate> updateRecords = new ArrayList<>();

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
 public class KintonePageOutput
         implements TransactionalPageOutput
 {
+    public static final int UPSERT_BATCH_SIZE = 10000;
+    public static final int CHUNK_SIZE = 100;
     private PageReader pageReader;
     private PluginTask task;
     private KintoneClient client;
@@ -136,7 +138,7 @@ public class KintonePageOutput
                     }
 
                     records.add(record);
-                    if (records.size() == 100) {
+                    if (records.size() == CHUNK_SIZE) {
                         client.record().addRecords(task.getAppId(), records);
                         records.clear();
                     }
@@ -180,7 +182,7 @@ public class KintonePageOutput
 
                     record.removeField(updateKey.getField());
                     updateRecords.add(new RecordForUpdate(updateKey, record));
-                    if (updateRecords.size() == 100) {
+                    if (updateRecords.size() == CHUNK_SIZE) {
                         client.record().updateRecords(task.getAppId(), updateRecords);
                         updateRecords.clear();
                     }
@@ -221,7 +223,7 @@ public class KintonePageOutput
                     records.add(record);
                     updateKeys.add(updateKey);
 
-                    if (records.size() == 10000) {
+                    if (records.size() == UPSERT_BATCH_SIZE) {
                         upsert(records, updateKeys);
                         records.clear();
                         updateKeys.clear();

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -3,9 +3,9 @@ package org.embulk.output.kintone;
 import com.kintone.client.KintoneClient;
 import com.kintone.client.KintoneClientBuilder;
 import com.kintone.client.api.record.GetRecordsByCursorResponseBody;
+import com.kintone.client.model.app.field.FieldProperty;
+import com.kintone.client.model.record.*;
 import com.kintone.client.model.record.Record;
-import com.kintone.client.model.record.RecordForUpdate;
-import com.kintone.client.model.record.UpdateKey;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class KintonePageOutput
@@ -186,6 +187,89 @@ public class KintonePageOutput
         });
     }
 
+    private void upsertPage(final Page page)
+    {
+        execute(client -> {
+            try {
+                ArrayList<Record> records = new ArrayList<>();
+                ArrayList<UpdateKey> updateKeys = new ArrayList<>();
+
+                pageReader.setPage(page);
+                KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,
+                        task.getColumnOptions(),
+                        task.getUpdateKeyName());
+                while (pageReader.nextRecord()) {
+                    Record record = new Record();
+                    UpdateKey updateKey = new UpdateKey();
+                    visitor.setRecord(record);
+                    visitor.setUpdateKey(updateKey);
+                    for (Column column : pageReader.getSchema().getColumns()) {
+                        column.visit(visitor);
+                    }
+                    records.add(record);
+                    updateKeys.add(updateKey);
+
+                    if (records.size() == 10000) {
+                        upsert(records, updateKeys);
+                        records.clear();
+                        updateKeys.clear();
+                    }
+                }
+                if (records.size() > 0) {
+                    upsert(records, updateKeys);
+                }
+            }
+            catch (Exception e) {
+                throw new RuntimeException("kintone throw exception", e);
+            }
+        });
+    }
+
+    private void upsert(ArrayList<Record> records, ArrayList<UpdateKey> updateKeys)
+    {
+        if (records.size() != updateKeys.size()) {
+            throw new RuntimeException("records.size() != updateKeys.size()");
+        }
+
+        String updateKeyField = updateKeys.get(0).getField();
+        List<String> queryValues = updateKeys
+                .stream()
+                .map(k -> "\"" + k.getValue().toString() + "\"")
+                .collect(Collectors.toList());
+        List<Record> distRecords = getRecordsByUpdateKey(updateKeyField, queryValues);
+
+        ArrayList<Record> insertRecords = new ArrayList<>();
+        ArrayList<RecordForUpdate> updateRecords = new ArrayList<>();
+        for (int i = 0; i < records.size(); i++) {
+            Record record = records.get(i);
+            UpdateKey updateKey = updateKeys.get(i);
+
+           if (existsRecord(distRecords, updateKey)) {
+               record.removeField(updateKey.getField());
+               updateRecords.add(new RecordForUpdate(updateKey, record));
+           }
+           else {
+               insertRecords.add(record);
+           }
+
+            if (insertRecords.size() == 100) {
+                client.record().addRecords(task.getAppId(), insertRecords);
+                insertRecords.clear();
+            }
+            else if (updateRecords.size() == 100) {
+                client.record().updateRecords(task.getAppId(), updateRecords);
+                updateRecords.clear();
+            }
+        }
+        if (insertRecords.size() > 0) {
+            client.record().addRecords(task.getAppId(), insertRecords);
+        }
+        if (updateRecords.size() > 0) {
+            client.record().updateRecords(task.getAppId(), updateRecords);
+        }
+    }
+
+
     private List<Record> getRecordsByUpdateKey(String fieldCode, List<String> queryValues)
     {
         List<Record> allRecords = new ArrayList<Record>();
@@ -207,163 +291,17 @@ public class KintonePageOutput
         return allRecords;
     }
 
-    abstract class UpsertPage<T>
+    private boolean existsRecord(List<Record> distRecords, UpdateKey updateKey)
     {
-        public abstract List<T> getUpdateKeyValues(List<String> queryValues);
-        public abstract boolean existsRecord(List<T> updateKeyValues, Record record);
-
-        public void upsert(ArrayList<Record> records, ArrayList<UpdateKey> updateKeys)
-        {
-            if (records.size() != updateKeys.size()) {
-                throw new RuntimeException("records.size() != updateKeys.size()");
-            }
-
-            List<String> queryValues = updateKeys
-                .stream()
-                .map(k -> "\"" + k.getValue().toString() + "\"")
-                .collect(Collectors.toList());
-            List<T> updateKeyValues = getUpdateKeyValues(queryValues);
-
-            ArrayList<Record> insertRecords = new ArrayList<>();
-            ArrayList<RecordForUpdate> updateRecords = new ArrayList<RecordForUpdate>();
-            for (int i = 0; i < records.size(); i++) {
-                Record record = records.get(i);
-                UpdateKey updateKey = updateKeys.get(i);
-
-                if (existsRecord(updateKeyValues, record)) {
-                    record.removeField(updateKey.getField());
-                    updateRecords.add(new RecordForUpdate(updateKey, record));
-                }
-                else {
-                    insertRecords.add(record);
-                }
-
-                if (insertRecords.size() == 100) {
-                    client.record().addRecords(task.getAppId(), insertRecords);
-                    insertRecords.clear();
-                }
-                else if (updateRecords.size() == 100) {
-                    client.record().updateRecords(task.getAppId(), updateRecords);
-                    updateRecords.clear();
-                }
-            }
-            if (insertRecords.size() > 0) {
-                client.record().addRecords(task.getAppId(), insertRecords);
-            }
-            if (updateRecords.size() > 0) {
-                client.record().updateRecords(task.getAppId(), updateRecords);
-            }
-        }
-
-        public void run(final Page page)
-        {
-            execute(client -> {
-                try {
-                    ArrayList<Record> records = new ArrayList<>();
-                    ArrayList<UpdateKey> updateKeys = new ArrayList<>();
-
-                    pageReader.setPage(page);
-                    KintoneColumnVisitor visitor = new KintoneColumnVisitor(pageReader,
-                            task.getColumnOptions(),
-                            task.getUpdateKeyName());
-                    while (pageReader.nextRecord()) {
-                        Record record = new Record();
-                        UpdateKey updateKey = new UpdateKey();
-                        visitor.setRecord(record);
-                        visitor.setUpdateKey(updateKey);
-                        for (Column column : pageReader.getSchema().getColumns()) {
-                            column.visit(visitor);
-                        }
-                        records.add(record);
-                        updateKeys.add(updateKey);
-
-                        if (records.size() == 10000) {
-                            upsert(records, updateKeys);
-                            records.clear();
-                            updateKeys.clear();
-                        }
-                    }
-                    if (records.size() > 0) {
-                        upsert(records, updateKeys);
-                    }
-                }
-                catch (Exception e) {
-                    throw new RuntimeException("kintone throw exception", e);
-                }
-            });
-        }
-    }
-
-    class UpsertPageByStringKey extends UpsertPage<String>
-    {
-        private String fieldCode;
-
-        public UpsertPageByStringKey(String fieldCode)
-        {
-            this.fieldCode = fieldCode;
-        }
-
-        public List<String> getUpdateKeyValues(List<String> queryValues)
-        {
-            return getRecordsByUpdateKey(fieldCode, queryValues)
-                .stream()
-                .map(r -> r.getSingleLineTextFieldValue(fieldCode))
-                .collect(Collectors.toList());
-        }
-
-        public boolean existsRecord(List<String> updateKeyValues, Record record)
-        {
-            return updateKeyValues.contains(record.getSingleLineTextFieldValue(fieldCode));
-        }
-    }
-
-    class UpsertPageByNumberKey extends UpsertPage<BigDecimal>
-    {
-        private String fieldCode;
-
-        public UpsertPageByNumberKey(String fieldCode)
-        {
-            this.fieldCode = fieldCode;
-        }
-
-        public List<BigDecimal> getUpdateKeyValues(List<String> queryValues)
-        {
-            return getRecordsByUpdateKey(fieldCode, queryValues)
-                .stream()
-                .map(r -> r.getNumberFieldValue(fieldCode))
-                .collect(Collectors.toList());
-        }
-
-        public boolean existsRecord(List<BigDecimal> updateKeyValues, Record record)
-        {
-            return updateKeyValues.contains(record.getNumberFieldValue(fieldCode));
-        }
-    }
-
-    private void upsertPage(final Page page)
-    {
-        KintoneColumnOption updateKeyColumn = null;
-        for (KintoneColumnOption v : task.getColumnOptions().values()) {
-            if (v.getUpdateKey()) {
-                updateKeyColumn = v;
-                break;
-            }
-        }
-        if (updateKeyColumn == null) {
-            throw new RuntimeException("when mode is upsert, require update_key");
-        }
-
-        UpsertPage runner;
-        switch(updateKeyColumn.getType()) {
-            case "SINGLE_LINE_TEXT":
-                runner = new UpsertPageByStringKey(updateKeyColumn.getFieldCode());
-                break;
-            case "NUMBER":
-                runner = new UpsertPageByNumberKey(updateKeyColumn.getFieldCode());
-                break;
+        String fieldCode = updateKey.getField();
+        FieldType type = client.app().getFormFields(task.getAppId()).get(fieldCode).getType();
+        switch (type) {
+            case SINGLE_LINE_TEXT:
+                return distRecords.stream().anyMatch(d -> d.getSingleLineTextFieldValue(fieldCode).equals(updateKey.getValue()));
+            case NUMBER:
+                return distRecords.stream().anyMatch(d -> d.getNumberFieldValue(fieldCode).equals(updateKey.getValue()));
             default:
                 throw new RuntimeException("The update_key must be 'SINGLE_LINE_TEXT' or 'NUMBER'.");
         }
-        runner.run(page);
     }
 }

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -13,7 +13,6 @@ import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/org/embulk/output/kintone/PluginTask.java
+++ b/src/main/java/org/embulk/output/kintone/PluginTask.java
@@ -50,5 +50,5 @@ public interface PluginTask
 
     @Config("update_key")
     @ConfigDefault("null")
-    public String getUpdateKeyName();
+    Optional<String> getUpdateKeyName();
 }

--- a/src/main/java/org/embulk/output/kintone/PluginTask.java
+++ b/src/main/java/org/embulk/output/kintone/PluginTask.java
@@ -47,4 +47,8 @@ public interface PluginTask
     @Config("mode")
     @ConfigDefault("insert")
     public String getMode();
+
+    @Config("update_key")
+    @ConfigDefault("null")
+    public String getUpdateKeyName();
 }


### PR DESCRIPTION
update_keyは1つしか指定できないのでconfig.ymlでの層を一つ上にする。
破壊的変更ですが、以下のメリットが有るかと思います。
  - update, upsert時にcolumn_optionを省略することができるようになる
  - コード、config.ymlの記述がシンプルになる。

その他： nullな値の取り回しにバグが有ったので修正しました