### PR TITLE
Fix bugs in comparing BigDecimal

### DIFF
--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -313,7 +313,8 @@ public class KintonePageOutput
             case NUMBER:
                 return distRecords
                         .stream()
-                        .anyMatch(d -> d.getNumberFieldValue(fieldCode).equals(updateKey.getValue()));
+                        .anyMatch(d -> d.getNumberFieldValue(fieldCode).toPlainString()
+                                        .equals(updateKey.getValue().toString()));
             default:
                 throw new RuntimeException("The update_key must be 'SINGLE_LINE_TEXT' or 'NUMBER'.");
         }

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -309,7 +309,7 @@ public class KintonePageOutput
             case SINGLE_LINE_TEXT:
                 return distRecords
                         .stream()
-                        .anyMatch(d -> d.getSingleLineTextFieldValue(fieldCode).equals(updateKey.getValue()));
+                        .anyMatch(d -> d.getSingleLineTextFieldValue(fieldCode).equals(updateKey.getValue().toString()));
             case NUMBER:
                 return distRecords
                         .stream()


### PR DESCRIPTION
`getNumberFieldValue` returns BigDecimal, so it is necessary to compare this after `toPlainString()` value.