### PR TITLE
Update CI workflow for branch and permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,17 @@ name: main
 on:
   push:
     branches:
-      - 'master'
+      - "master"
     tags:
-      - '*'
+      - "*"
   pull_request:
     branches:
-      - 'master'
+      - "master"
     types: [opened, synchronize]
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   main:


### PR DESCRIPTION
Fixed a possible lack of permissions for `GITHUB_TOKEN`.

Below is the reference link:
- https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token