### PR TITLE
fix gem path for publishing RubyGems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           # TODO: If it is possible to accept input in the middle of a step, then the OTP Token should be inputted instead of generated.
           gem install rotp -v 6.2.0
           OTP_TOKEN=$(echo ${OTP_SECRET} | ruby -rtime -rrotp -e "puts ROTP::TOTP.new(STDIN.read.chomp, issuer: 'rubygems.org').at(Time.now)")
-          gem push --otp="${OTP_TOKEN}" ./pkg/*.gem
+          gem push --otp="${OTP_TOKEN}" ./build/gems/*.gem
         env:
           GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_API_KEY}}"
           OTP_SECRET: "${{secrets.RUBYGEMS_OTP_SECRET}}"


### PR DESCRIPTION
In https://github.com/trocco-io/embulk-output-kintone/pull/48, I fixed gem path for publishing to GPR.
But I forgot to fix it for publishing RubyGems...
