### PR TITLE
Add structured error logging for failed Kintone API records

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ kintone output plugin for Embulk stores app records from kintone.
         - **name**: Column name (string, required)
         - **order**: Sort order (string `asc` or `desc`, required)
 - **chunk_size**: Maximum number of records to request at once (integer, default is `100`)
+- **error_records_detail_output_file**: Output file path for detailed error records in JSONL format. When Kintone API errors occur, failed records are logged with their data, error codes, and error messages. Each line contains a JSON object with `record_data`, `error_code`, and `error_message` fields (string, optional)
 
 ## Example
 
@@ -56,6 +57,7 @@ out:
   app_id: 1
   mode: upsert
   update_key: id
+  error_records_detail_output_file: /tmp/kintone_error_records.jsonl
   column_options:
     id: {field_code: "id", type: "NUMBER"}
     name: {field_code: "name", type: "SINGLE_LINE_TEXT"}
@@ -109,6 +111,27 @@ ID:2
 | NUMBER        | SINGLE_LINE_TEXT |
 | ------------- | ---------------- |
 | 0             | test0            |
+
+## Error Records Detail Output
+
+When `error_records_detail_output_file` is configured, failed records are logged in JSONL format. Each line contains a JSON object with the following structure:
+
+```json
+{"record_data":{"id":"123","name":"John Doe"},"error_code":"GAIA_RE01","error_message":"Field validation error: name: This field is required"}
+```
+
+### Fields
+
+- **record_data**: Original record data that failed to be processed
+- **error_code**: Kintone API error code (e.g., GAIA_RE01, GAIA_RE18)  
+- **error_message**: Detailed error message including field-specific errors
+
+### Example Error Log File
+
+```
+{"record_data":{"id":"001","email":"invalid-email"},"error_code":"GAIA_RE01","error_message":"Field validation error: email: Invalid email format"}
+{"record_data":{"id":"002","required_field":null},"error_code":"GAIA_RE01","error_message":"Field validation error: required_field: This field is required"}
+```
 
 ## Build
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation "com.google.inject:guice:4.0"
     implementation "com.google.code.externalsortinginjava:externalsortinginjava:0.6.2"
     implementation 'org.apache.commons:commons-lang3:3.4'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation project(path: ":shadow-kintone-java-client", configuration: "shadow")
 
     testImplementation "junit:junit:4.+"

--- a/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
+++ b/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Kintoneエラーを収集し、構造化してファイルに出力するクラス */
+/** Class for collecting Kintone errors, structuring them, and outputting to a file */
 public class ErrorFileLogger implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(ErrorFileLogger.class);
   private static final int FLUSH_INTERVAL = 100;
@@ -76,11 +76,11 @@ public class ErrorFileLogger implements AutoCloseable {
   }
 
   /**
-   * Kintoneエラーを記録
+   * Logs Kintone errors
    *
-   * @param recordData 元のレコードデータ（Map形式）
-   * @param errorCode エラーコード
-   * @param errorMessage エラーメッセージ（フィールドエラーも含む）
+   * @param recordData Original record data (Map format)
+   * @param errorCode Error code
+   * @param errorMessage Error message (including field errors)
    */
   public void logError(Map<String, Object> recordData, String errorCode, String errorMessage) {
     if (!enabled) {
@@ -127,7 +127,7 @@ public class ErrorFileLogger implements AutoCloseable {
       try {
         writer.flush();
         writer.close();
-        writer = null; // 複数回のclose呼び出しを防ぐ
+        writer = null; // Prevent multiple close calls
 
         if (errorCount == 0 && filePath != null) {
           Files.deleteIfExists(filePath);

--- a/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
+++ b/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
@@ -1,12 +1,18 @@
 package org.embulk.output.kintone;
 
 import java.io.*;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.function.Function;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
@@ -32,11 +38,11 @@ public class ErrorFileLogger implements AutoCloseable {
     private int errorCount = 0;
     
     /**
-     * エラーレコードの内部クラス
+     * Error record class for JSON serialization
      */
     private static class ErrorRecord {
         @SerializedName("record_data")
-        private final java.util.Map<String, Object> recordData;
+        private final Map<String, Object> recordData;
         
         @SerializedName("error_code")
         private final String errorCode;
@@ -44,28 +50,10 @@ public class ErrorFileLogger implements AutoCloseable {
         @SerializedName("error_message")
         private final String errorMessage;
         
-        @SerializedName("affected_fields")
-        private final String[] affectedFields;
-        
-        @SerializedName("timestamp")
-        private final String timestamp;
-        
-        @SerializedName("task_index")
-        private final Integer taskIndex;
-        
-        @SerializedName("record_index")
-        private final Integer recordIndex;
-        
-        ErrorRecord(java.util.Map<String, Object> recordData,
-                   String errorCode, String errorMessage,
-                   String[] affectedFields, Integer taskIndex, Integer recordIndex) {
+        ErrorRecord(Map<String, Object> recordData, String errorCode, String errorMessage) {
             this.recordData = recordData;
             this.errorCode = errorCode != null ? errorCode : "";
             this.errorMessage = errorMessage != null ? errorMessage : "";
-            this.affectedFields = affectedFields;
-            this.timestamp = Instant.now().toString();
-            this.taskIndex = taskIndex;
-            this.recordIndex = recordIndex;
         }
     }
     
@@ -105,33 +93,19 @@ public class ErrorFileLogger implements AutoCloseable {
     
     /**
      * Kintoneエラーを記録
-     * @param record 元のレコードデータ
+     * @param recordData 元のレコードデータ（Map形式）
      * @param errorCode エラーコード
      * @param errorMessage エラーメッセージ（フィールドエラーも含む）
-     * @param affectedFields 影響を受けたフィールドのリスト
-     * @param recordIndex レコードインデックス
      */
-    public void logError(Record record, String errorCode, String errorMessage, 
-                         String[] affectedFields, int recordIndex) {
+    public void logError(Map<String, Object> recordData, String errorCode, String errorMessage) {
         if (!enabled) {
             return;
         }
         
-        java.util.Map<String, Object> recordData = extractAllFields(record);
-        
-        ErrorRecord errorRecord = new ErrorRecord(
-            recordData,
-            errorCode,
-            errorMessage,
-            affectedFields,
-            taskIndex,
-            recordIndex
-        );
-        
+        ErrorRecord errorRecord = new ErrorRecord(recordData, errorCode, errorMessage);
         writeRecord(errorRecord);
         errorCount++;
     }
-    
     
     private void writeRecord(ErrorRecord record) {
         if (writer == null) {
@@ -150,136 +124,9 @@ public class ErrorFileLogger implements AutoCloseable {
             logger.error("Failed to write error record", e);
         }
     }
-    
-    /**
-     * Recordから全フィールドを抽出
-     */
-    private java.util.Map<String, Object> extractAllFields(Record record) {
-        java.util.Map<String, Object> fields = new java.util.HashMap<>();
-        
-        if (record == null) {
-            return fields;
-        }
-        
-        // Recordオブジェクトから全フィールドを取得
-        record.getFieldCodes(true).forEach(fieldCode -> {
-            Object value = record.getFieldValue(fieldCode);
-            if (value != null) {
-                // 実際の値を取得
-                Object actualValue = extractActualValue(value);
-                fields.put(fieldCode, actualValue);
-            } else {
-                fields.put(fieldCode, null);
-            }
-        });
-        
-        return fields;
-    }
-    
-    /**
-     * FieldValueオブジェクトから実際の値を抽出
-     */
-    private Object extractActualValue(Object value) {
-        if (value == null) {
-            return null;
-        }
-        
-        // SingleLineTextFieldValue, MultiLineTextFieldValue などの場合
-        if (value instanceof com.kintone.client.model.record.SingleLineTextFieldValue) {
-            return ((com.kintone.client.model.record.SingleLineTextFieldValue) value).getValue();
-        } else if (value instanceof com.kintone.client.model.record.MultiLineTextFieldValue) {
-            return ((com.kintone.client.model.record.MultiLineTextFieldValue) value).getValue();
-        } else if (value instanceof com.kintone.client.model.record.NumberFieldValue) {
-            com.kintone.client.model.record.NumberFieldValue numberValue = 
-                (com.kintone.client.model.record.NumberFieldValue) value;
-            return numberValue.getValue() != null ? numberValue.getValue().toString() : null;
-        } else if (value instanceof com.kintone.client.model.record.CheckBoxFieldValue) {
-            com.kintone.client.model.record.CheckBoxFieldValue checkBoxValue = 
-                (com.kintone.client.model.record.CheckBoxFieldValue) value;
-            return checkBoxValue.getValues();
-        } else if (value instanceof com.kintone.client.model.record.RadioButtonFieldValue) {
-            return ((com.kintone.client.model.record.RadioButtonFieldValue) value).getValue();
-        } else if (value instanceof com.kintone.client.model.record.DropDownFieldValue) {
-            return ((com.kintone.client.model.record.DropDownFieldValue) value).getValue();
-        } else if (value instanceof com.kintone.client.model.record.DateFieldValue) {
-            com.kintone.client.model.record.DateFieldValue dateValue = 
-                (com.kintone.client.model.record.DateFieldValue) value;
-            return dateValue.getValue() != null ? dateValue.getValue().toString() : null;
-        } else if (value instanceof com.kintone.client.model.record.DateTimeFieldValue) {
-            com.kintone.client.model.record.DateTimeFieldValue dateTimeValue = 
-                (com.kintone.client.model.record.DateTimeFieldValue) value;
-            return dateTimeValue.getValue() != null ? dateTimeValue.getValue().toString() : null;
-        } else if (value instanceof com.kintone.client.model.record.TimeFieldValue) {
-            com.kintone.client.model.record.TimeFieldValue timeValue = 
-                (com.kintone.client.model.record.TimeFieldValue) value;
-            return timeValue.getValue() != null ? timeValue.getValue().toString() : null;
-        } else if (value instanceof com.kintone.client.model.record.LinkFieldValue) {
-            return ((com.kintone.client.model.record.LinkFieldValue) value).getValue();
-        } else if (value instanceof com.kintone.client.model.record.RichTextFieldValue) {
-            return ((com.kintone.client.model.record.RichTextFieldValue) value).getValue();
-        } else if (value instanceof com.kintone.client.model.record.MultiSelectFieldValue) {
-            com.kintone.client.model.record.MultiSelectFieldValue multiSelectValue = 
-                (com.kintone.client.model.record.MultiSelectFieldValue) value;
-            return multiSelectValue.getValues();
-        } else if (value instanceof com.kintone.client.model.record.UserSelectFieldValue) {
-            com.kintone.client.model.record.UserSelectFieldValue userSelectValue = 
-                (com.kintone.client.model.record.UserSelectFieldValue) value;
-            java.util.List<String> users = new java.util.ArrayList<>();
-            if (userSelectValue.getValues() != null) {
-                userSelectValue.getValues().forEach(user -> users.add(user.getCode()));
-            }
-            return users;
-        } else if (value instanceof com.kintone.client.model.record.GroupSelectFieldValue) {
-            com.kintone.client.model.record.GroupSelectFieldValue groupSelectValue = 
-                (com.kintone.client.model.record.GroupSelectFieldValue) value;
-            java.util.List<String> groups = new java.util.ArrayList<>();
-            if (groupSelectValue.getValues() != null) {
-                groupSelectValue.getValues().forEach(group -> groups.add(group.getCode()));
-            }
-            return groups;
-        } else if (value instanceof com.kintone.client.model.record.OrganizationSelectFieldValue) {
-            com.kintone.client.model.record.OrganizationSelectFieldValue orgSelectValue = 
-                (com.kintone.client.model.record.OrganizationSelectFieldValue) value;
-            java.util.List<String> orgs = new java.util.ArrayList<>();
-            if (orgSelectValue.getValues() != null) {
-                orgSelectValue.getValues().forEach(org -> orgs.add(org.getCode()));
-            }
-            return orgs;
-        } else if (value instanceof com.kintone.client.model.record.FileFieldValue) {
-            com.kintone.client.model.record.FileFieldValue fileValue = 
-                (com.kintone.client.model.record.FileFieldValue) value;
-            java.util.List<String> fileKeys = new java.util.ArrayList<>();
-            if (fileValue.getValues() != null) {
-                fileValue.getValues().forEach(file -> fileKeys.add(file.getFileKey()));
-            }
-            return fileKeys;
-        } else {
-            // その他のFieldValueタイプや通常のオブジェクトの場合
-            return value.toString();
-        }
-    }
-    
+
     private String generateFilePath() {
-        String basePath = outputPath;
-        
-        // ディレクトリパスの場合の処理
-        if (basePath.endsWith("/") || basePath.endsWith("\\")) {
-            // ディレクトリの場合、デフォルトファイル名を追加
-            basePath = basePath + "kintone_errors.jsonl";
-        } else if (!basePath.contains(".")) {
-            // 拡張子がない場合、ディレクトリとみなして処理
-            if (!basePath.endsWith(java.io.File.separator)) {
-                basePath = basePath + java.io.File.separator;
-            }
-            basePath = basePath + "kintone_errors.jsonl";
-        } else if (!basePath.endsWith(".jsonl")) {
-            // 別の拡張子がある場合、.jsonlに変更
-            basePath = basePath.substring(0, basePath.lastIndexOf(".")) + ".jsonl";
-        }
-        
-        // タスクインデックスを含むファイル名を生成
-        String base = basePath.substring(0, basePath.lastIndexOf(".jsonl"));
-        return String.format("%s_task%03d.jsonl", base, taskIndex);
+        return String.format("%s_task%03d.jsonl", outputPath, taskIndex);
     }
     
     private void ensureDirectoryExists(Path path) throws IOException {

--- a/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
+++ b/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
@@ -1,0 +1,309 @@
+package org.embulk.output.kintone;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import com.kintone.client.model.record.Record;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Kintoneエラーを収集し、構造化してファイルに出力するクラス
+ */
+public class ErrorFileLogger implements AutoCloseable {
+    private static final Logger logger = LoggerFactory.getLogger(ErrorFileLogger.class);
+    private static final int FLUSH_INTERVAL = 100;
+    
+    private final String outputPath;
+    private final int taskIndex;
+    private final Gson gson;
+    private boolean enabled;
+    
+    private BufferedWriter writer;
+    private Path filePath;
+    private int recordCount = 0;
+    private int errorCount = 0;
+    
+    /**
+     * エラーレコードの内部クラス
+     */
+    private static class ErrorRecord {
+        @SerializedName("record_data")
+        private final java.util.Map<String, Object> recordData;
+        
+        @SerializedName("error_code")
+        private final String errorCode;
+        
+        @SerializedName("error_message")
+        private final String errorMessage;
+        
+        @SerializedName("affected_fields")
+        private final String[] affectedFields;
+        
+        @SerializedName("timestamp")
+        private final String timestamp;
+        
+        @SerializedName("task_index")
+        private final Integer taskIndex;
+        
+        @SerializedName("record_index")
+        private final Integer recordIndex;
+        
+        ErrorRecord(java.util.Map<String, Object> recordData,
+                   String errorCode, String errorMessage,
+                   String[] affectedFields, Integer taskIndex, Integer recordIndex) {
+            this.recordData = recordData;
+            this.errorCode = errorCode != null ? errorCode : "";
+            this.errorMessage = errorMessage != null ? errorMessage : "";
+            this.affectedFields = affectedFields;
+            this.timestamp = Instant.now().toString();
+            this.taskIndex = taskIndex;
+            this.recordIndex = recordIndex;
+        }
+    }
+    
+    public ErrorFileLogger(String outputPath, int taskIndex) {
+        this.outputPath = outputPath;
+        this.taskIndex = taskIndex;
+        this.gson = new GsonBuilder().disableHtmlEscaping().create();
+        this.enabled = outputPath != null && !outputPath.trim().isEmpty();
+        
+        
+        if (enabled) {
+            try {
+                open();
+            } catch (IOException e) {
+                logger.error("Failed to open error file for writing", e);
+                this.enabled = false;
+            }
+        }
+    }
+    
+    private void open() throws IOException {
+        if (!enabled || writer != null) {
+            return;
+        }
+        
+        this.filePath = Paths.get(generateFilePath());
+        ensureDirectoryExists(filePath);
+        
+        this.writer = Files.newBufferedWriter(
+            filePath,
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND
+        );
+        
+    }
+    
+    /**
+     * Kintoneエラーを記録
+     * @param record 元のレコードデータ
+     * @param errorCode エラーコード
+     * @param errorMessage エラーメッセージ（フィールドエラーも含む）
+     * @param affectedFields 影響を受けたフィールドのリスト
+     * @param recordIndex レコードインデックス
+     */
+    public void logError(Record record, String errorCode, String errorMessage, 
+                         String[] affectedFields, int recordIndex) {
+        if (!enabled) {
+            return;
+        }
+        
+        java.util.Map<String, Object> recordData = extractAllFields(record);
+        
+        ErrorRecord errorRecord = new ErrorRecord(
+            recordData,
+            errorCode,
+            errorMessage,
+            affectedFields,
+            taskIndex,
+            recordIndex
+        );
+        
+        writeRecord(errorRecord);
+        errorCount++;
+    }
+    
+    
+    private void writeRecord(ErrorRecord record) {
+        if (writer == null) {
+            return;
+        }
+        
+        try {
+            writer.write(gson.toJson(record));
+            writer.newLine();
+            recordCount++;
+            
+            if (recordCount % FLUSH_INTERVAL == 0) {
+                writer.flush();
+            }
+        } catch (IOException e) {
+            logger.error("Failed to write error record", e);
+        }
+    }
+    
+    /**
+     * Recordから全フィールドを抽出
+     */
+    private java.util.Map<String, Object> extractAllFields(Record record) {
+        java.util.Map<String, Object> fields = new java.util.HashMap<>();
+        
+        if (record == null) {
+            return fields;
+        }
+        
+        // Recordオブジェクトから全フィールドを取得
+        record.getFieldCodes(true).forEach(fieldCode -> {
+            Object value = record.getFieldValue(fieldCode);
+            if (value != null) {
+                // 実際の値を取得
+                Object actualValue = extractActualValue(value);
+                fields.put(fieldCode, actualValue);
+            } else {
+                fields.put(fieldCode, null);
+            }
+        });
+        
+        return fields;
+    }
+    
+    /**
+     * FieldValueオブジェクトから実際の値を抽出
+     */
+    private Object extractActualValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        
+        // SingleLineTextFieldValue, MultiLineTextFieldValue などの場合
+        if (value instanceof com.kintone.client.model.record.SingleLineTextFieldValue) {
+            return ((com.kintone.client.model.record.SingleLineTextFieldValue) value).getValue();
+        } else if (value instanceof com.kintone.client.model.record.MultiLineTextFieldValue) {
+            return ((com.kintone.client.model.record.MultiLineTextFieldValue) value).getValue();
+        } else if (value instanceof com.kintone.client.model.record.NumberFieldValue) {
+            com.kintone.client.model.record.NumberFieldValue numberValue = 
+                (com.kintone.client.model.record.NumberFieldValue) value;
+            return numberValue.getValue() != null ? numberValue.getValue().toString() : null;
+        } else if (value instanceof com.kintone.client.model.record.CheckBoxFieldValue) {
+            com.kintone.client.model.record.CheckBoxFieldValue checkBoxValue = 
+                (com.kintone.client.model.record.CheckBoxFieldValue) value;
+            return checkBoxValue.getValues();
+        } else if (value instanceof com.kintone.client.model.record.RadioButtonFieldValue) {
+            return ((com.kintone.client.model.record.RadioButtonFieldValue) value).getValue();
+        } else if (value instanceof com.kintone.client.model.record.DropDownFieldValue) {
+            return ((com.kintone.client.model.record.DropDownFieldValue) value).getValue();
+        } else if (value instanceof com.kintone.client.model.record.DateFieldValue) {
+            com.kintone.client.model.record.DateFieldValue dateValue = 
+                (com.kintone.client.model.record.DateFieldValue) value;
+            return dateValue.getValue() != null ? dateValue.getValue().toString() : null;
+        } else if (value instanceof com.kintone.client.model.record.DateTimeFieldValue) {
+            com.kintone.client.model.record.DateTimeFieldValue dateTimeValue = 
+                (com.kintone.client.model.record.DateTimeFieldValue) value;
+            return dateTimeValue.getValue() != null ? dateTimeValue.getValue().toString() : null;
+        } else if (value instanceof com.kintone.client.model.record.TimeFieldValue) {
+            com.kintone.client.model.record.TimeFieldValue timeValue = 
+                (com.kintone.client.model.record.TimeFieldValue) value;
+            return timeValue.getValue() != null ? timeValue.getValue().toString() : null;
+        } else if (value instanceof com.kintone.client.model.record.LinkFieldValue) {
+            return ((com.kintone.client.model.record.LinkFieldValue) value).getValue();
+        } else if (value instanceof com.kintone.client.model.record.RichTextFieldValue) {
+            return ((com.kintone.client.model.record.RichTextFieldValue) value).getValue();
+        } else if (value instanceof com.kintone.client.model.record.MultiSelectFieldValue) {
+            com.kintone.client.model.record.MultiSelectFieldValue multiSelectValue = 
+                (com.kintone.client.model.record.MultiSelectFieldValue) value;
+            return multiSelectValue.getValues();
+        } else if (value instanceof com.kintone.client.model.record.UserSelectFieldValue) {
+            com.kintone.client.model.record.UserSelectFieldValue userSelectValue = 
+                (com.kintone.client.model.record.UserSelectFieldValue) value;
+            java.util.List<String> users = new java.util.ArrayList<>();
+            if (userSelectValue.getValues() != null) {
+                userSelectValue.getValues().forEach(user -> users.add(user.getCode()));
+            }
+            return users;
+        } else if (value instanceof com.kintone.client.model.record.GroupSelectFieldValue) {
+            com.kintone.client.model.record.GroupSelectFieldValue groupSelectValue = 
+                (com.kintone.client.model.record.GroupSelectFieldValue) value;
+            java.util.List<String> groups = new java.util.ArrayList<>();
+            if (groupSelectValue.getValues() != null) {
+                groupSelectValue.getValues().forEach(group -> groups.add(group.getCode()));
+            }
+            return groups;
+        } else if (value instanceof com.kintone.client.model.record.OrganizationSelectFieldValue) {
+            com.kintone.client.model.record.OrganizationSelectFieldValue orgSelectValue = 
+                (com.kintone.client.model.record.OrganizationSelectFieldValue) value;
+            java.util.List<String> orgs = new java.util.ArrayList<>();
+            if (orgSelectValue.getValues() != null) {
+                orgSelectValue.getValues().forEach(org -> orgs.add(org.getCode()));
+            }
+            return orgs;
+        } else if (value instanceof com.kintone.client.model.record.FileFieldValue) {
+            com.kintone.client.model.record.FileFieldValue fileValue = 
+                (com.kintone.client.model.record.FileFieldValue) value;
+            java.util.List<String> fileKeys = new java.util.ArrayList<>();
+            if (fileValue.getValues() != null) {
+                fileValue.getValues().forEach(file -> fileKeys.add(file.getFileKey()));
+            }
+            return fileKeys;
+        } else {
+            // その他のFieldValueタイプや通常のオブジェクトの場合
+            return value.toString();
+        }
+    }
+    
+    private String generateFilePath() {
+        String basePath = outputPath;
+        
+        // ディレクトリパスの場合の処理
+        if (basePath.endsWith("/") || basePath.endsWith("\\")) {
+            // ディレクトリの場合、デフォルトファイル名を追加
+            basePath = basePath + "kintone_errors.jsonl";
+        } else if (!basePath.contains(".")) {
+            // 拡張子がない場合、ディレクトリとみなして処理
+            if (!basePath.endsWith(java.io.File.separator)) {
+                basePath = basePath + java.io.File.separator;
+            }
+            basePath = basePath + "kintone_errors.jsonl";
+        } else if (!basePath.endsWith(".jsonl")) {
+            // 別の拡張子がある場合、.jsonlに変更
+            basePath = basePath.substring(0, basePath.lastIndexOf(".")) + ".jsonl";
+        }
+        
+        // タスクインデックスを含むファイル名を生成
+        String base = basePath.substring(0, basePath.lastIndexOf(".jsonl"));
+        return String.format("%s_task%03d.jsonl", base, taskIndex);
+    }
+    
+    private void ensureDirectoryExists(Path path) throws IOException {
+        Path parent = path.getParent();
+        if (parent != null && !Files.exists(parent)) {
+            Files.createDirectories(parent);
+        }
+    }
+    
+    
+    @Override
+    public void close() {
+        if (writer != null) {
+            try {
+                writer.flush();
+                writer.close();
+                writer = null;  // 複数回のclose呼び出しを防ぐ
+                
+                if (errorCount == 0 && filePath != null) {
+                    Files.deleteIfExists(filePath);
+                }
+            } catch (IOException e) {
+                logger.error("Failed to close error file", e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
+++ b/src/main/java/org/embulk/output/kintone/ErrorFileLogger.java
@@ -49,7 +49,7 @@ public class ErrorFileLogger implements AutoCloseable {
   public ErrorFileLogger(String outputPath, int taskIndex) {
     this.outputPath = outputPath;
     this.taskIndex = taskIndex;
-    this.gson = new GsonBuilder().disableHtmlEscaping().create();
+    this.gson = new GsonBuilder().disableHtmlEscaping().serializeNulls().create();
     this.enabled = outputPath != null && !outputPath.trim().isEmpty();
 
     if (enabled) {

--- a/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
@@ -1,5 +1,13 @@
 package org.embulk.output.kintone;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.List;
 import org.embulk.config.ConfigDiff;
@@ -14,8 +22,11 @@ import org.embulk.spi.TransactionalPageOutput;
 import org.embulk.util.config.ConfigMapper;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.embulk.util.config.TaskMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KintoneOutputPlugin implements OutputPlugin {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KintoneOutputPlugin.class);
   private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
       ConfigMapperFactory.builder().addDefaultModules().build();
   private static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
@@ -41,7 +52,12 @@ public class KintoneOutputPlugin implements OutputPlugin {
 
   @Override
   public void cleanup(
-      TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> successTaskReports) {}
+      TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> successTaskReports) {
+    PluginTask task = TASK_MAPPER.map(taskSource, PluginTask.class);
+    
+    // Concatenate error files if error output is configured
+    task.getErrorRecordsDetailOutputFile().ifPresent(this::concatenateErrorFiles);
+  }
 
   @Override
   public TransactionalPageOutput open(TaskSource taskSource, Schema schema, int taskIndex) {
@@ -49,5 +65,34 @@ public class KintoneOutputPlugin implements OutputPlugin {
     return task.getReduceKeyName().isPresent()
         ? new ReducedPageOutput(schema, taskIndex)
         : new KintonePageOutput(task, schema, taskIndex);
+  }
+
+  private void concatenateErrorFiles(String outputFile) {
+    Path outputPath = Paths.get(outputFile);
+    Path directory = outputPath.getParent();
+    String baseFileName = outputPath.getFileName().toString();
+    
+    try (BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+      Files.list(directory)
+          .filter(path -> path.getFileName().toString().startsWith(baseFileName + "_task"))
+          .sorted()
+          .forEach(taskFile -> {
+            try {
+              Files.lines(taskFile).forEach(line -> {
+                try {
+                  writer.write(line);
+                  writer.newLine();
+                } catch (IOException e) {
+                  LOGGER.error("Failed to write line", e);
+                }
+              });
+              Files.deleteIfExists(taskFile);
+            } catch (IOException e) {
+              LOGGER.error("Failed to process task file: " + taskFile, e);
+            }
+          });
+    } catch (IOException e) {
+      LOGGER.error("Failed to concatenate error files", e);
+    }
   }
 }

--- a/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
+++ b/src/main/java/org/embulk/output/kintone/KintoneOutputPlugin.java
@@ -48,6 +48,6 @@ public class KintoneOutputPlugin implements OutputPlugin {
     PluginTask task = TASK_MAPPER.map(taskSource, PluginTask.class);
     return task.getReduceKeyName().isPresent()
         ? new ReducedPageOutput(schema, taskIndex)
-        : new KintonePageOutput(task, schema);
+        : new KintonePageOutput(task, schema, taskIndex);
   }
 }

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -529,10 +529,6 @@ public class KintonePageOutput implements TransactionalPageOutput {
               String combinedMessage = String.join("\n", errorMessages);
               errorFileLogger.logError(recordData, errorCode, combinedMessage);
             });
-      } else {
-        // Log as general error when errors field is not present
-        LOGGER.warn(
-            "Kintone API error without field-level errors: " + errorCode + " - " + errorMessage);
       }
     } catch (IOException ex) {
       LOGGER.error("Failed to parse Kintone API error response", ex);
@@ -594,16 +590,9 @@ public class KintonePageOutput implements TransactionalPageOutput {
       return null;
     }
 
-    Object extractedValue = tryExtractValue(value);
-    if (extractedValue != null) {
-      return extractedValue;
-    }
-
-    // Fallback for unknown types
-    return value.toString();
+    return tryExtractValue(value);
   }
 
-  /** Attempts to extract value using reflection with smart handling of different field types */
   private Object tryExtractValue(Object value) {
     try {
       // First try getValue() method (most common case)

--- a/src/main/java/org/embulk/output/kintone/PluginTask.java
+++ b/src/main/java/org/embulk/output/kintone/PluginTask.java
@@ -89,9 +89,9 @@ public interface PluginTask extends Task {
   @ConfigDefault("{}")
   KintoneRetryOption getRetryOptions();
 
-  @Config("error_output_path")
+  @Config("error_records_detail_output_file")
   @ConfigDefault("null")
-  Optional<String> getErrorOutputPath();
+  Optional<String> getErrorRecordsDetailOutputFile();
 
   Set<Column> getDerivedColumns();
 

--- a/src/main/java/org/embulk/output/kintone/PluginTask.java
+++ b/src/main/java/org/embulk/output/kintone/PluginTask.java
@@ -89,6 +89,10 @@ public interface PluginTask extends Task {
   @ConfigDefault("{}")
   KintoneRetryOption getRetryOptions();
 
+  @Config("error_output_path")
+  @ConfigDefault("null")
+  Optional<String> getErrorOutputPath();
+
   Set<Column> getDerivedColumns();
 
   void setDerivedColumns(Set<Column> columns);

--- a/src/test/java/org/embulk/output/kintone/ErrorFileLoggerTest.java
+++ b/src/test/java/org/embulk/output/kintone/ErrorFileLoggerTest.java
@@ -1,0 +1,292 @@
+package org.embulk.output.kintone;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ErrorFileLoggerTest {
+  private static final String TEST_OUTPUT_DIR = "build/test-output";
+  private static final String TEST_OUTPUT_FILE = TEST_OUTPUT_DIR + "/error_test";
+  private Path testDir;
+  private ErrorFileLogger logger;
+
+  @Before
+  public void setUp() throws IOException {
+    testDir = Paths.get(TEST_OUTPUT_DIR);
+    if (!Files.exists(testDir)) {
+      Files.createDirectories(testDir);
+    }
+    cleanupTestFiles();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (logger != null) {
+      logger.close();
+    }
+    cleanupTestFiles();
+  }
+
+  private void cleanupTestFiles() throws IOException {
+    if (Files.exists(testDir)) {
+      Files.list(testDir)
+          .filter(path -> path.getFileName().toString().startsWith("error_test"))
+          .forEach(
+              path -> {
+                try {
+                  Files.deleteIfExists(path);
+                } catch (IOException e) {
+                  // Ignore
+                }
+              });
+    }
+  }
+
+  @Test
+  public void testLogError() throws IOException {
+    logger = new ErrorFileLogger(TEST_OUTPUT_FILE, 1);
+
+    Map<String, Object> recordData = new HashMap<>();
+    recordData.put("id", "123");
+    recordData.put("name", "Test User");
+    recordData.put("email", "test@example.com");
+
+    logger.logError(recordData, "GAIA_RE01", "Field validation error: email: Invalid format");
+    logger.close();
+
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE + "_task001.jsonl");
+    assertTrue("Output file should exist", Files.exists(outputFile));
+
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have one line", lines.size(), is(1));
+
+    Gson gson = new Gson();
+    JsonObject jsonObject = gson.fromJson(lines.get(0), JsonObject.class);
+
+    assertThat(
+        "Should have error_code", jsonObject.get("error_code").getAsString(), is("GAIA_RE01"));
+    assertThat(
+        "Should have error_message",
+        jsonObject.get("error_message").getAsString(),
+        is("Field validation error: email: Invalid format"));
+
+    JsonObject recordDataJson = jsonObject.getAsJsonObject("record_data");
+    assertThat("Should have id in record_data", recordDataJson.get("id").getAsString(), is("123"));
+    assertThat(
+        "Should have name in record_data",
+        recordDataJson.get("name").getAsString(),
+        is("Test User"));
+    assertThat(
+        "Should have email in record_data",
+        recordDataJson.get("email").getAsString(),
+        is("test@example.com"));
+  }
+
+  @Test
+  public void testMultipleErrors() throws IOException {
+    logger = new ErrorFileLogger(TEST_OUTPUT_FILE, 2);
+
+    Map<String, Object> recordData1 = new HashMap<>();
+    recordData1.put("id", "001");
+    recordData1.put("field1", "value1");
+
+    Map<String, Object> recordData2 = new HashMap<>();
+    recordData2.put("id", "002");
+    recordData2.put("field2", "value2");
+
+    logger.logError(recordData1, "ERR_001", "First error message");
+    logger.logError(recordData2, "ERR_002", "Second error message");
+    logger.close();
+
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE + "_task002.jsonl");
+    assertTrue("Output file should exist", Files.exists(outputFile));
+
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have two lines", lines.size(), is(2));
+
+    Gson gson = new Gson();
+    JsonObject firstError = gson.fromJson(lines.get(0), JsonObject.class);
+    JsonObject secondError = gson.fromJson(lines.get(1), JsonObject.class);
+
+    assertThat(
+        "First error should have correct code",
+        firstError.get("error_code").getAsString(),
+        is("ERR_001"));
+    assertThat(
+        "Second error should have correct code",
+        secondError.get("error_code").getAsString(),
+        is("ERR_002"));
+  }
+
+  @Test
+  public void testNullValues() throws IOException {
+    logger = new ErrorFileLogger(TEST_OUTPUT_FILE, 3);
+
+    Map<String, Object> recordData = new HashMap<>();
+    recordData.put("id", "123");
+    recordData.put("nullField", null);
+
+    logger.logError(recordData, null, null);
+    logger.close();
+
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE + "_task003.jsonl");
+    assertTrue("Output file should exist", Files.exists(outputFile));
+
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have one line", lines.size(), is(1));
+
+    // Check that null values are handled properly
+    assertThat(
+        "Should contain nullField with null value",
+        lines.get(0),
+        containsString("\"nullField\":null"));
+    assertThat("Should have empty error_code", lines.get(0), containsString("\"error_code\":\"\""));
+    assertThat(
+        "Should have empty error_message", lines.get(0), containsString("\"error_message\":\"\""));
+  }
+
+  @Test
+  public void testEmptyFileIsDeleted() throws IOException {
+    logger = new ErrorFileLogger(TEST_OUTPUT_FILE, 4);
+    logger.close();
+
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE + "_task004.jsonl");
+    assertFalse("Empty file should be deleted", Files.exists(outputFile));
+  }
+
+  @Test
+  public void testDisabledLogger() throws IOException {
+    // Create logger with null output path
+    logger = new ErrorFileLogger(null, 5);
+
+    Map<String, Object> recordData = new HashMap<>();
+    recordData.put("id", "123");
+
+    // This should not throw any exception and should not create any file
+    logger.logError(recordData, "ERR", "Error message");
+    logger.close();
+
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE + "_task005.jsonl");
+    assertFalse("No file should be created when logger is disabled", Files.exists(outputFile));
+  }
+
+  @Test
+  public void testEmptyOutputPath() throws IOException {
+    // Create logger with empty output path
+    logger = new ErrorFileLogger("", 6);
+
+    Map<String, Object> recordData = new HashMap<>();
+    recordData.put("id", "123");
+
+    // This should not throw any exception and should not create any file
+    logger.logError(recordData, "ERR", "Error message");
+    logger.close();
+
+    // No assertion for file existence as no file should be created
+  }
+
+  @Test
+  public void testDirectoryCreation() throws IOException {
+    String nestedPath = TEST_OUTPUT_DIR + "/nested/dir/error_test";
+    logger = new ErrorFileLogger(nestedPath, 7);
+
+    Map<String, Object> recordData = new HashMap<>();
+    recordData.put("id", "123");
+
+    logger.logError(recordData, "ERR", "Error message");
+    logger.close();
+
+    Path outputFile = Paths.get(nestedPath + "_task007.jsonl");
+    assertTrue("Output file should exist in nested directory", Files.exists(outputFile));
+
+    // Cleanup nested directories
+    Files.deleteIfExists(outputFile);
+    Files.deleteIfExists(Paths.get(TEST_OUTPUT_DIR + "/nested/dir"));
+    Files.deleteIfExists(Paths.get(TEST_OUTPUT_DIR + "/nested"));
+  }
+
+  @Test
+  public void testLargeRecordData() throws IOException {
+    logger = new ErrorFileLogger(TEST_OUTPUT_FILE, 8);
+
+    Map<String, Object> recordData = new HashMap<>();
+    for (int i = 0; i < 100; i++) {
+      recordData.put("field_" + i, "value_" + i);
+    }
+
+    logger.logError(recordData, "ERR", "Error with large record");
+    logger.close();
+
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE + "_task008.jsonl");
+    assertTrue("Output file should exist", Files.exists(outputFile));
+
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have one line", lines.size(), is(1));
+
+    // Verify all fields are present
+    for (int i = 0; i < 100; i++) {
+      assertThat(
+          "Should contain field_" + i,
+          lines.get(0),
+          containsString("\"field_" + i + "\":\"value_" + i + "\""));
+    }
+  }
+
+  @Test
+  public void testSpecialCharactersInData() throws IOException {
+    logger = new ErrorFileLogger(TEST_OUTPUT_FILE, 9);
+
+    Map<String, Object> recordData = new HashMap<>();
+    recordData.put("field1", "Value with \"quotes\"");
+    recordData.put("field2", "Value with\nnewline");
+    recordData.put("field3", "Value with\ttab");
+    recordData.put("field4", "Value with \\backslash");
+
+    logger.logError(
+        recordData, "ERR", "Error message with special chars: \"quotes\" and\nnewlines");
+    logger.close();
+
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE + "_task009.jsonl");
+    assertTrue("Output file should exist", Files.exists(outputFile));
+
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have one line", lines.size(), is(1));
+
+    Gson gson = new Gson();
+    JsonObject jsonObject = gson.fromJson(lines.get(0), JsonObject.class);
+    JsonObject recordDataJson = jsonObject.getAsJsonObject("record_data");
+
+    assertThat(
+        "Should handle quotes properly",
+        recordDataJson.get("field1").getAsString(),
+        is("Value with \"quotes\""));
+    assertThat(
+        "Should handle newline properly",
+        recordDataJson.get("field2").getAsString(),
+        is("Value with\nnewline"));
+    assertThat(
+        "Should handle tab properly",
+        recordDataJson.get("field3").getAsString(),
+        is("Value with\ttab"));
+    assertThat(
+        "Should handle backslash properly",
+        recordDataJson.get("field4").getAsString(),
+        is("Value with \\backslash"));
+  }
+}

--- a/src/test/java/org/embulk/output/kintone/KintoneOutputPluginErrorFileConcatenationTest.java
+++ b/src/test/java/org/embulk/output/kintone/KintoneOutputPluginErrorFileConcatenationTest.java
@@ -1,0 +1,321 @@
+package org.embulk.output.kintone;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KintoneOutputPluginErrorFileConcatenationTest {
+  private static final String TEST_OUTPUT_DIR = "build/test-output";
+  private static final String TEST_OUTPUT_FILE = TEST_OUTPUT_DIR + "/concatenated_errors.jsonl";
+  private Path testDir;
+  private TestableKintoneOutputPlugin plugin;
+
+  // Extend KintoneOutputPlugin to expose concatenateErrorFiles for testing
+  private static class TestableKintoneOutputPlugin extends KintoneOutputPlugin {
+    public void concatenateErrorFiles(String outputFile) {
+      // Use reflection to call private method
+      try {
+        java.lang.reflect.Method method =
+            KintoneOutputPlugin.class.getDeclaredMethod("concatenateErrorFiles", String.class);
+        method.setAccessible(true);
+        method.invoke(this, outputFile);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    testDir = Paths.get(TEST_OUTPUT_DIR);
+    if (!Files.exists(testDir)) {
+      Files.createDirectories(testDir);
+    }
+    cleanupTestFiles();
+    plugin = new TestableKintoneOutputPlugin();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    cleanupTestFiles();
+  }
+
+  private void cleanupTestFiles() throws IOException {
+    if (Files.exists(testDir)) {
+      Files.list(testDir)
+          .filter(
+              path -> {
+                String fileName = path.getFileName().toString();
+                return fileName.contains("_task") || fileName.equals("concatenated_errors.jsonl");
+              })
+          .forEach(
+              path -> {
+                try {
+                  Files.deleteIfExists(path);
+                } catch (IOException e) {
+                  // Ignore
+                }
+              });
+    }
+  }
+
+  @Test
+  public void testConcatenateErrorFiles() throws IOException {
+    // Create multiple task error files
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task000.jsonl",
+        "{\"record_data\":{\"id\":\"001\"},\"error_code\":\"ERR1\",\"error_message\":\"Error 1\"}");
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task001.jsonl",
+        "{\"record_data\":{\"id\":\"002\"},\"error_code\":\"ERR2\",\"error_message\":\"Error 2\"}",
+        "{\"record_data\":{\"id\":\"003\"},\"error_code\":\"ERR3\",\"error_message\":\"Error 3\"}");
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task002.jsonl",
+        "{\"record_data\":{\"id\":\"004\"},\"error_code\":\"ERR4\",\"error_message\":\"Error 4\"}");
+
+    // Call the concatenate method
+    plugin.concatenateErrorFiles(TEST_OUTPUT_FILE);
+
+    // Verify the output file exists
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE);
+    assertTrue("Concatenated file should exist", Files.exists(outputFile));
+
+    // Verify the content
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have 4 lines", lines.size(), is(4));
+
+    // Parse and verify each line
+    Gson gson = new Gson();
+    List<String> ids = new ArrayList<>();
+    List<String> errorCodes = new ArrayList<>();
+
+    for (String line : lines) {
+      JsonObject json = gson.fromJson(line, JsonObject.class);
+      JsonObject recordData = json.getAsJsonObject("record_data");
+      ids.add(recordData.get("id").getAsString());
+      errorCodes.add(json.get("error_code").getAsString());
+    }
+
+    assertThat(ids, containsInAnyOrder("001", "002", "003", "004"));
+    assertThat(errorCodes, containsInAnyOrder("ERR1", "ERR2", "ERR3", "ERR4"));
+
+    // Verify task files are deleted
+    assertFalse(
+        "Task file 0 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task000.jsonl")));
+    assertFalse(
+        "Task file 1 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task001.jsonl")));
+    assertFalse(
+        "Task file 2 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task002.jsonl")));
+  }
+
+  @Test
+  public void testConcatenateEmptyFiles() throws IOException {
+    // Create empty task files
+    createTaskErrorFile(TEST_OUTPUT_FILE + "_task000.jsonl");
+    createTaskErrorFile(TEST_OUTPUT_FILE + "_task001.jsonl");
+    createTaskErrorFile(TEST_OUTPUT_FILE + "_task002.jsonl");
+
+    // Call the concatenate method
+    plugin.concatenateErrorFiles(TEST_OUTPUT_FILE);
+
+    // Verify the output file does not exist (deleted because it's empty)
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE);
+    assertFalse("Empty concatenated file should be deleted", Files.exists(outputFile));
+
+    // Verify task files are deleted
+    assertFalse(
+        "Task file 0 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task000.jsonl")));
+    assertFalse(
+        "Task file 1 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task001.jsonl")));
+    assertFalse(
+        "Task file 2 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task002.jsonl")));
+  }
+
+  @Test
+  public void testConcatenateMixedFiles() throws IOException {
+    // Create mix of empty and non-empty task files
+    createTaskErrorFile(TEST_OUTPUT_FILE + "_task000.jsonl"); // Empty
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task001.jsonl",
+        "{\"record_data\":{\"id\":\"100\"},\"error_code\":\"ERR\",\"error_message\":\"Error\"}");
+    createTaskErrorFile(TEST_OUTPUT_FILE + "_task002.jsonl"); // Empty
+
+    // Call the concatenate method
+    plugin.concatenateErrorFiles(TEST_OUTPUT_FILE);
+
+    // Verify the output file exists
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE);
+    assertTrue("Concatenated file should exist", Files.exists(outputFile));
+
+    // Verify the content
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have 1 line", lines.size(), is(1));
+
+    Gson gson = new Gson();
+    JsonObject json = gson.fromJson(lines.get(0), JsonObject.class);
+    JsonObject recordData = json.getAsJsonObject("record_data");
+    assertThat(recordData.get("id").getAsString(), is("100"));
+    assertThat(json.get("error_code").getAsString(), is("ERR"));
+
+    // Verify task files are deleted
+    assertFalse(
+        "Task file 0 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task000.jsonl")));
+    assertFalse(
+        "Task file 1 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task001.jsonl")));
+    assertFalse(
+        "Task file 2 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task002.jsonl")));
+  }
+
+  @Test
+  public void testConcatenateNoTaskFiles() throws IOException {
+    // Call the concatenate method without creating any task files
+    plugin.concatenateErrorFiles(TEST_OUTPUT_FILE);
+
+    // Verify no output file is created
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE);
+    assertFalse(
+        "No output file should be created when no task files exist", Files.exists(outputFile));
+  }
+
+  @Test
+  public void testConcatenateMissingTaskFiles() throws IOException {
+    // Create only some task files (not all)
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task000.jsonl",
+        "{\"record_data\":{\"id\":\"001\"},\"error_code\":\"ERR1\",\"error_message\":\"Error 1\"}");
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task002.jsonl",
+        "{\"record_data\":{\"id\":\"002\"},\"error_code\":\"ERR2\",\"error_message\":\"Error 2\"}");
+    // _task001.jsonl is missing
+
+    // Call the concatenate method
+    plugin.concatenateErrorFiles(TEST_OUTPUT_FILE);
+
+    // Verify the output file exists
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE);
+    assertTrue("Concatenated file should exist", Files.exists(outputFile));
+
+    // Verify the content (should contain data from existing files)
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have 2 lines", lines.size(), is(2));
+
+    // Verify existing task files are deleted
+    assertFalse(
+        "Task file 0 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task000.jsonl")));
+    assertFalse(
+        "Task file 2 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task002.jsonl")));
+  }
+
+  @Test
+  public void testConcatenateWithLargeContent() throws IOException {
+    // Create task files with multiple lines
+    List<String> largeContent = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      largeContent.add(
+          String.format(
+              "{\"record_data\":{\"id\":\"%03d\"},\"error_code\":\"ERR\",\"error_message\":\"Error %d\"}",
+              i, i));
+    }
+
+    createTaskErrorFile(TEST_OUTPUT_FILE + "_task000.jsonl", largeContent.toArray(new String[0]));
+    createTaskErrorFile(TEST_OUTPUT_FILE + "_task001.jsonl", largeContent.toArray(new String[0]));
+
+    // Call the concatenate method
+    plugin.concatenateErrorFiles(TEST_OUTPUT_FILE);
+
+    // Verify the output file exists
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE);
+    assertTrue("Concatenated file should exist", Files.exists(outputFile));
+
+    // Verify the content
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have 200 lines", lines.size(), is(200));
+
+    // Verify task files are deleted
+    assertFalse(
+        "Task file 0 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task000.jsonl")));
+    assertFalse(
+        "Task file 1 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task001.jsonl")));
+  }
+
+  @Test
+  public void testConcatenateWithSpecialCharacters() throws IOException {
+    // Create task files with special characters
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task000.jsonl",
+        "{\"record_data\":{\"text\":\"Line with\\nnewline\"},\"error_code\":\"ERR\",\"error_message\":\"Error with \\\"quotes\\\"\"}");
+    createTaskErrorFile(
+        TEST_OUTPUT_FILE + "_task001.jsonl",
+        "{\"record_data\":{\"text\":\"Tab\\there\"},\"error_code\":\"ERR\",\"error_message\":\"Backslash \\\\ test\"}");
+
+    // Call the concatenate method
+    plugin.concatenateErrorFiles(TEST_OUTPUT_FILE);
+
+    // Verify the output file exists
+    Path outputFile = Paths.get(TEST_OUTPUT_FILE);
+    assertTrue("Concatenated file should exist", Files.exists(outputFile));
+
+    // Verify the content
+    List<String> lines = Files.readAllLines(outputFile, StandardCharsets.UTF_8);
+    assertThat("Should have 2 lines", lines.size(), is(2));
+
+    // Parse and verify special characters are preserved
+    Gson gson = new Gson();
+    JsonObject json1 = gson.fromJson(lines.get(0), JsonObject.class);
+    JsonObject recordData1 = json1.getAsJsonObject("record_data");
+    assertThat(recordData1.get("text").getAsString(), is("Line with\nnewline"));
+    assertThat(json1.get("error_message").getAsString(), is("Error with \"quotes\""));
+
+    JsonObject json2 = gson.fromJson(lines.get(1), JsonObject.class);
+    JsonObject recordData2 = json2.getAsJsonObject("record_data");
+    assertThat(recordData2.get("text").getAsString(), is("Tab\there"));
+    assertThat(json2.get("error_message").getAsString(), is("Backslash \\ test"));
+
+    // Verify task files are deleted
+    assertFalse(
+        "Task file 0 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task000.jsonl")));
+    assertFalse(
+        "Task file 1 should be deleted",
+        Files.exists(Paths.get(TEST_OUTPUT_FILE + "_task001.jsonl")));
+  }
+
+  private void createTaskErrorFile(String filename, String... lines) throws IOException {
+    Path filePath = Paths.get(filename);
+    try (BufferedWriter writer = Files.newBufferedWriter(filePath, StandardCharsets.UTF_8)) {
+      for (String line : lines) {
+        writer.write(line);
+        writer.newLine();
+      }
+    }
+  }
+}

--- a/src/test/resources/org/embulk/output/kintone/config.yml
+++ b/src/test/resources/org/embulk/output/kintone/config.yml
@@ -2,3 +2,4 @@ type: kintone
 domain: domain
 app_id: 0
 token: token
+error_records_detail_output_file: /tmp/test_kintone_errors.jsonl


### PR DESCRIPTION
## Summary

Add structured error logging functionality to capture detailed information about failed Kintone API records in JSONL format.

## Changes

- **New configuration**: `error_records_detail_output_file` - Optional file path to output detailed error records
- **Error logging**: Failed records are logged with record data, error code, and error message in JSONL format
- **Task-based processing**: Each Embulk task writes to separate files (e.g., `errors_task000.jsonl`, `errors_task001.jsonl`)
- **File consolidation**: All task files are automatically merged into the final output file during cleanup
- **Code improvements**: Refactored error handling logic and translated Japanese comments to English

## Configuration Example

```yaml
out:
  type: kintone
  domain: example.cybozu.com
  app_id: 123
  token: your_token
  error_records_detail_output_file: /tmp/kintone_errors.jsonl
```

## Error Log Format

Each line in the output file contains a JSON object:
```json
{"record_data":{"field1":"value1","field2":"value2"},"error_code":"GAIA_RE01","error_message":"Field validation error"}
```
