### PR TITLE
fix: restore update key value in error log record data

### DIFF
--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -550,46 +550,40 @@ public class KintonePageOutput implements TransactionalPageOutput {
     }
   }
 
-  /** Converts list of records to list of maps for easier handling */
+  /** Converts list of records to list of maps for easier handling. */
   static List<Map<String, Object>> convertRecordsToMaps(List<?> records) {
     List<Map<String, Object>> recordMaps = new ArrayList<>();
-
-    for (Object recordObj : records) {
-      Record record = null;
-      RecordForUpdate recordForUpdate = null;
-
-      if (recordObj instanceof Record) {
-        record = (Record) recordObj;
-      } else if (recordObj instanceof RecordForUpdate) {
-        recordForUpdate = (RecordForUpdate) recordObj;
-        record = recordForUpdate.getRecord();
-      }
-
-      if (record != null) {
-        Map<String, Object> recordData = extractAllFieldsFromRecord(record);
-        // In IdOrUpdateKey.forUpdate(), the update key field is removed from the Record before
-        // being wrapped in RecordForUpdate because the kintone API forbids including the
-        // updateKey field in the request body (responds with CB_VA01 / "「updateKey」に指定した
-        // フィールドの値は更新できません。"). As a result, the Record alone no longer carries
-        // the value that identifies the failed row. Restore it here so the error log includes
-        // the identifier value.
-        if (recordForUpdate != null) {
-          if (recordForUpdate.getId() != null) {
-            recordData.putIfAbsent(Id.FIELD, recordForUpdate.getId());
-          }
-          UpdateKey updateKey = recordForUpdate.getUpdateKey();
-          if (updateKey != null && updateKey.getField() != null && updateKey.getValue() != null) {
-            recordData.putIfAbsent(updateKey.getField(), updateKey.getValue());
-          }
-        }
-        recordMaps.add(recordData);
+    for (Object obj : records) {
+      if (obj instanceof RecordForUpdate) {
+        RecordForUpdate rfu = (RecordForUpdate) obj;
+        Map<String, Object> map = extractAllFieldsFromRecord(rfu.getRecord());
+        restoreIdentifier(map, rfu);
+        recordMaps.add(map);
+      } else if (obj instanceof Record) {
+        recordMaps.add(extractAllFieldsFromRecord((Record) obj));
       } else {
-        // Add empty map for unknown types to maintain index consistency
+        // Unknown type: add an empty map so indices stay aligned with the input list.
         recordMaps.add(new HashMap<>());
       }
     }
-
     return recordMaps;
+  }
+
+  /**
+   * Restores the identifier ($id or update key) that was removed from the Record in {@code
+   * IdOrUpdateKey#forUpdate}. The update key field is stripped before the API call because kintone
+   * rejects requests that carry the updateKey field in the record body (CB_VA01 /
+   * "「updateKey」に指定したフィールドの値は更新できません。"), but we still need the value in the error log to identify
+   * which input row failed.
+   */
+  private static void restoreIdentifier(Map<String, Object> map, RecordForUpdate rfu) {
+    if (rfu.getId() != null) {
+      map.putIfAbsent(Id.FIELD, rfu.getId());
+    }
+    UpdateKey updateKey = rfu.getUpdateKey();
+    if (updateKey != null && updateKey.getField() != null && updateKey.getValue() != null) {
+      map.putIfAbsent(updateKey.getField(), updateKey.getValue());
+    }
   }
 
   /** Extracts all fields from a Record object to Map */

--- a/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
+++ b/src/main/java/org/embulk/output/kintone/KintonePageOutput.java
@@ -24,6 +24,7 @@ import com.kintone.client.model.record.RecordForUpdate;
 import com.kintone.client.model.record.RichTextFieldValue;
 import com.kintone.client.model.record.SingleLineTextFieldValue;
 import com.kintone.client.model.record.TimeFieldValue;
+import com.kintone.client.model.record.UpdateKey;
 import com.kintone.client.model.record.UserSelectFieldValue;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -550,20 +551,37 @@ public class KintonePageOutput implements TransactionalPageOutput {
   }
 
   /** Converts list of records to list of maps for easier handling */
-  private List<Map<String, Object>> convertRecordsToMaps(List<?> records) {
+  static List<Map<String, Object>> convertRecordsToMaps(List<?> records) {
     List<Map<String, Object>> recordMaps = new ArrayList<>();
 
     for (Object recordObj : records) {
       Record record = null;
+      RecordForUpdate recordForUpdate = null;
 
       if (recordObj instanceof Record) {
         record = (Record) recordObj;
       } else if (recordObj instanceof RecordForUpdate) {
-        record = ((RecordForUpdate) recordObj).getRecord();
+        recordForUpdate = (RecordForUpdate) recordObj;
+        record = recordForUpdate.getRecord();
       }
 
       if (record != null) {
         Map<String, Object> recordData = extractAllFieldsFromRecord(record);
+        // In IdOrUpdateKey.forUpdate(), the update key field is removed from the Record before
+        // being wrapped in RecordForUpdate because the kintone API forbids including the
+        // updateKey field in the request body (responds with CB_VA01 / "「updateKey」に指定した
+        // フィールドの値は更新できません。"). As a result, the Record alone no longer carries
+        // the value that identifies the failed row. Restore it here so the error log includes
+        // the identifier value.
+        if (recordForUpdate != null) {
+          if (recordForUpdate.getId() != null) {
+            recordData.putIfAbsent(Id.FIELD, recordForUpdate.getId());
+          }
+          UpdateKey updateKey = recordForUpdate.getUpdateKey();
+          if (updateKey != null && updateKey.getField() != null && updateKey.getValue() != null) {
+            recordData.putIfAbsent(updateKey.getField(), updateKey.getValue());
+          }
+        }
         recordMaps.add(recordData);
       } else {
         // Add empty map for unknown types to maintain index consistency
@@ -575,7 +593,7 @@ public class KintonePageOutput implements TransactionalPageOutput {
   }
 
   /** Extracts all fields from a Record object to Map */
-  private Map<String, Object> extractAllFieldsFromRecord(Record record) {
+  private static Map<String, Object> extractAllFieldsFromRecord(Record record) {
     Map<String, Object> fields = new HashMap<>();
 
     if (record == null) {
@@ -599,7 +617,7 @@ public class KintonePageOutput implements TransactionalPageOutput {
   }
 
   /** Extracts actual value from FieldValue object using type-safe instanceof checks */
-  private Object extractActualValue(Object value) {
+  private static Object extractActualValue(Object value) {
     if (value == null) {
       return null;
     }

--- a/src/test/java/org/embulk/output/kintone/KintonePageOutputConvertRecordsTest.java
+++ b/src/test/java/org/embulk/output/kintone/KintonePageOutputConvertRecordsTest.java
@@ -1,0 +1,104 @@
+package org.embulk.output.kintone;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.kintone.client.model.record.Record;
+import com.kintone.client.model.record.RecordForUpdate;
+import com.kintone.client.model.record.SingleLineTextFieldValue;
+import com.kintone.client.model.record.UpdateKey;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.embulk.output.kintone.record.Id;
+import org.junit.Test;
+
+/**
+ * Unit tests for KintonePageOutput#convertRecordsToMaps(List).
+ *
+ * <p>Verifies that the identifier (update key or $id) is preserved in the map emitted for an error
+ * record. The Record wrapped by RecordForUpdate has the update key field removed before the API
+ * call (required by the kintone API), so this logic must restore it from the RecordForUpdate
+ * itself.
+ */
+public class KintonePageOutputConvertRecordsTest {
+
+  private static List<Map<String, Object>> invoke(List<?> records) {
+    return KintonePageOutput.convertRecordsToMaps(records);
+  }
+
+  @Test
+  public void recordForUpdateWithUpdateKey_restoresUpdateKeyField() throws Exception {
+    Record record = new Record();
+    record.putField("memo", new SingleLineTextFieldValue("hello"));
+    UpdateKey updateKey = new UpdateKey().setField("external_id").setValue("EXT-001");
+
+    RecordForUpdate recordForUpdate = new RecordForUpdate(updateKey, record);
+
+    List<Map<String, Object>> result = invoke(Collections.singletonList(recordForUpdate));
+
+    assertThat(result.size(), is(1));
+    Map<String, Object> map = result.get(0);
+    assertThat(map, hasEntry("memo", "hello"));
+    // The update key field must be restored even though Record no longer carries it.
+    assertThat(map, hasEntry("external_id", (Object) "EXT-001"));
+  }
+
+  @Test
+  public void recordForUpdateWithId_restoresIdField() throws Exception {
+    Record record = new Record();
+    record.putField("memo", new SingleLineTextFieldValue("hello"));
+
+    RecordForUpdate recordForUpdate = new RecordForUpdate(123L, record);
+
+    List<Map<String, Object>> result = invoke(Collections.singletonList(recordForUpdate));
+
+    assertThat(result.size(), is(1));
+    Map<String, Object> map = result.get(0);
+    assertThat(map, hasEntry("memo", "hello"));
+    assertThat(map, hasEntry(Id.FIELD, (Object) 123L));
+  }
+
+  @Test
+  public void plainRecord_isPassedThroughUnchanged() throws Exception {
+    Record record = new Record();
+    record.putField("memo", new SingleLineTextFieldValue("hello"));
+
+    List<Map<String, Object>> result = invoke(Collections.singletonList(record));
+
+    assertThat(result.size(), is(1));
+    Map<String, Object> map = result.get(0);
+    assertThat(map, hasEntry("memo", "hello"));
+  }
+
+  @Test
+  public void unknownRecordType_yieldsEmptyMap() throws Exception {
+    List<Map<String, Object>> result = invoke(Collections.singletonList("not a record"));
+
+    assertThat(result.size(), is(1));
+    assertThat(result.get(0), is(not(nullValue())));
+    assertThat(result.get(0).isEmpty(), is(true));
+  }
+
+  @Test
+  public void mixedList_preservesIndexAndIdentifiers() throws Exception {
+    Record plain = new Record();
+    plain.putField("memo", new SingleLineTextFieldValue("plain"));
+
+    Record withKey = new Record();
+    withKey.putField("memo", new SingleLineTextFieldValue("keyed"));
+    UpdateKey updateKey = new UpdateKey().setField("external_id").setValue("EXT-002");
+    RecordForUpdate recordForUpdate = new RecordForUpdate(updateKey, withKey);
+
+    List<Map<String, Object>> result = invoke(Arrays.asList(plain, recordForUpdate));
+
+    assertThat(result.size(), is(2));
+    assertThat(result.get(0), hasEntry("memo", "plain"));
+    assertThat(result.get(1), hasEntry("memo", "keyed"));
+    assertThat(result.get(1), hasEntry("external_id", (Object) "EXT-002"));
+  }
+}


### PR DESCRIPTION
## Summary

When a row fails during `update` / `upsert`, the error log JSONL written by `ErrorFileLogger` was missing the update key value for that row, even though `identifier_keys_for_error_log` consumers expect it to be there. This PR restores the update key (either the user-configured update key or `\$id`) in the `record_data` emitted for failed rows.

## Why the value was missing

`IdOrUpdateKey.forUpdate()` removes the update key field from the `Record` before wrapping it in `RecordForUpdate`:

```java
// record/IdOrUpdateKey.java
public RecordForUpdate forUpdate(Record record) {
  return isIdPresent()
      ? new RecordForUpdate(id.getValue(), record)
      : new RecordForUpdate(updateKey, record.removeField(updateKey.getField()));
}
```

This is **required by the kintone API**. Including the updateKey field in the request body causes the server to reject the request with:

```
400 CB_VA01 入力内容が正しくありません。
errors: { \"record[<field>]\": [\"「updateKey」に指定したフィールドの値は更新できません。\"] }
```

So removing the field is correct on the request path. The side effect is that `KintonePageOutput#convertRecordsToMaps` — which walks the records to build `record_data` for error logging — only sees the post-removal `Record`, so the identifier never reaches the JSONL.

## Fix

In `convertRecordsToMaps`, when the item is a `RecordForUpdate`, also read `getId()` / `getUpdateKey()` and merge the value into the map for that row. `putIfAbsent` is used so that any value already present on the Record (unlikely, but safe) wins.

- `RecordForUpdate(long id, Record)` -> adds \`\$id\` -> id value
- `RecordForUpdate(UpdateKey, Record)` -> adds <updateKey.field> -> updateKey.value

The request path is unchanged; the Record sent to the API still has the update key field removed.

## Testing

- New unit test `KintonePageOutputConvertRecordsTest` covers:
  - `RecordForUpdate` with an `UpdateKey` -> field/value is restored
  - `RecordForUpdate` with an `\$id` -> `\$id` is restored
  - Plain `Record` -> passed through unchanged
  - Unknown object type -> empty map (index consistency preserved)
  - Mixed list preserves index and identifiers per-row
- All existing tests pass (`./gradlew test`)
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` pass

`convertRecordsToMaps` and its helpers (`extractAllFieldsFromRecord`, `extractActualValue`) are changed from `private` to `private static` / package-private `static` so the logic can be unit-tested without constructing a real `KintonePageOutput` (which would require a PageReader / KintoneClient / Schema). The methods were already free of instance state, so this is a purely mechanical change.